### PR TITLE
Modifica breadcrumb

### DIFF
--- a/design-italia/functions.php
+++ b/design-italia/functions.php
@@ -404,7 +404,7 @@ function wppa_breadcrumb() {
     echo '</a></li>';
     if (is_category() || is_single()) {
       echo '<li class="breadcrumb-item">';
-      the_category(' </li><li class="breadcrumb-item"> ');
+      echo implode(' </li><li class="breadcrumb-item"> ',array_reverse(explode(',',get_the_category_list(','))));
       if (is_single()) {
         echo '</li><li class="breadcrumb-item">';
         the_title();


### PR DESCRIPTION
Ciao penso sia una modifica utile:

in pratica se l'articolo è assegnato a due categorie di cui una genitore, queste vengo visualizzate nella breadcrumb in ordine alfabetico, e spesso la parent viene mostrata dopo la child.

con la mia modifica invece viene sempre rispettato l'ordine gerarchico delle categorie:
home > categoria genitore > categoria figlia > nome post

p.s. sarebbe poi fantastico se rendessi "pluggable" tutte le funzioni del tema (tramite if !function_exist) così si potrebbe sovrascrivere facilmente in un tema child.

