### PR TITLE
Modifica del breadcrumb per custom post type

### DIFF
--- a/design-italia/functions.php
+++ b/design-italia/functions.php
@@ -420,7 +420,7 @@ if ( ! function_exists( 'wppa_breadcrumb' ) ) {
 	if(get_post_type() != 'post'){
 		$post_type = get_post_type_object(get_post_type());
 		$slug = $post_type->rewrite;
-		echo '<li class="breadcrumb-item"><a href="' . $homeLink . '/' . $slug['slug'] . '/">' . $post_type->labels->menu_name . '</a></li>';				
+		echo '<li class="breadcrumb-item"><a href="' . home_url()  . '/' . $slug['slug'] . '/">' . $post_type->labels->menu_name . '</a></li>';				
 		echo '<li class="breadcrumb-item">';
 		the_title();
 		echo '</li>';


### PR DESCRIPTION
Se si inseriscono dei custom post type il breadcrumb non gestisce la tipologia di post aggiuntiva.
La modifica permette di visualizzare nel breadcrumb il parametro "menu_name" presente nelle labels del custom post type.